### PR TITLE
Fix native code conflict caused by Array.values()

### DIFF
--- a/src/util/XTemplate.js
+++ b/src/util/XTemplate.js
@@ -202,7 +202,7 @@ Ext2.XTemplate = function(){
        }
        if(name){
            switch(name){
-               case '.': name = new Function('values', 'parent', 'with(values){ return values; }'); break;
+               case '.': name = new Function('values', 'parent', 'return values;'); break;
                case '..': name = new Function('values', 'parent', 'with(values){ return parent; }'); break;
                default: name = new Function('values', 'parent', 'with(values){ return '+name+'; }');
            }


### PR DESCRIPTION
When a function with(values) { return values; } is called, IE11 invokes the
native function .values() on an array. The argument 'values' is disregarded.
Therefore we return values without passing it through the additional function.